### PR TITLE
Allow option dispatching with instance methods through :with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,24 @@ class ProductSearch
 end
 ```
 
+### Using instance method for straight dispatch
+
+```ruby
+class ProductSearch
+  include SearchObject.module
+
+  scope { Product.all }
+
+  option :date, with: :parse_dates
+
+  private
+
+  def parse_dates(scope, value)
+    # some "magic" method to parse dates
+  end
+end
+```
+
 ### Active Record is not required at all
 
 ```ruby

--- a/spec/search_object/base_spec.rb
+++ b/spec/search_object/base_spec.rb
@@ -121,6 +121,20 @@ module SearchObject
 
         expect(search1.results).to eq [1]
       end
+
+      it "can dispatch with instance methods" do
+        search = new_search [1, 2, 3], filter: 1 do
+          option :filter, with: :some_instance_method
+
+          private
+
+          def some_instance_method(scope, value)
+            scope.select { |v| v == value }
+          end
+        end
+
+        expect(search.results).to eq [1]
+      end
     end
 
     describe "option attributes" do


### PR DESCRIPTION
In my projects I tend to use search object with instance methods ala
ActiveSupport::Rescuable. I think its a quite handy feature to have.

Cheers!