### PR TITLE
Fix inheriting issue with configuration clone

### DIFF
--- a/lib/search_object/base.rb
+++ b/lib/search_object/base.rb
@@ -45,11 +45,7 @@ module SearchObject
       attr_reader :config
 
       def inherited(base)
-        new_config = config.dup
-
-        base.instance_eval do
-          @config = new_config
-        end
+        base.instance_variable_set '@config', Helper.deep_copy(config)
       end
 
       def scope(&block)

--- a/lib/search_object/helper.rb
+++ b/lib/search_object/helper.rb
@@ -39,6 +39,22 @@ module SearchObject
         else ->(scope, value) { scope.where name => value unless value.blank? }
         end
       end
+
+      def deep_copy(object) # rubocop:disable Metrics/MethodLength
+        case object
+        when Array
+          object.map { |element| deep_copy(element) }
+        when Hash
+          object.inject({}) do |result, (key, value)|
+            result[key] = deep_copy(value)
+            result
+          end
+        when NilClass, FalseClass, TrueClass, Symbol, Method, Numeric
+          object
+        else
+          object.dup
+        end
+      end
     end
   end
 end

--- a/spec/search_object/base_spec.rb
+++ b/spec/search_object/base_spec.rb
@@ -61,13 +61,20 @@ module SearchObject
     end
 
     it 'can be inherited' do
-      child_class = Class.new(search_class([1, 2, 3])) do
+      equality_search = Class.new(search_class([1, 2, 3])) do
         option :value do |scope, value|
           scope.select { |v| v == value }
         end
       end
 
-      expect(child_class.new(filters: { value: 1 }).results).to eq [1]
+      inequality_search = Class.new(search_class([1, 2, 3])) do
+        option :value do |scope, value|
+          scope.select { |v| v > value }
+        end
+      end
+
+      expect(equality_search.new(filters: { value: 1 }).results).to eq [1]
+      expect(inequality_search.new(filters: { value: 1 }).results).to eq [2, 3]
     end
 
     context 'scope' do

--- a/spec/search_object/helper_spec.rb
+++ b/spec/search_object/helper_spec.rb
@@ -26,5 +26,30 @@ module SearchObject
         expect(Helper.camelize(:paging)).to eq 'Paging'
       end
     end
+
+    describe 'deep_copy' do
+      it 'returns a deep copy on the given object' do
+        original = {
+          array: [1, 2, 3],
+          hash: { key: 'value' },
+          boolean: true,
+          number: 1,
+          null: nil
+        }
+
+        deep_copy = Helper.deep_copy(original)
+
+        original[:array][0] = 42
+        original[:hash][:key] = 'other value'
+
+        expect(deep_copy).to eq(
+          array: [1, 2, 3],
+          hash: { key: 'value' },
+          boolean: true,
+          number: 1,
+          null: nil
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The current `config.dup` does not do a deep copy, which means that `defaults`, `actions`, `scope` will be shared with all subclasses. That's not cool especially if you have the same option in different subclasses since that option will be overwritten.