### PR TITLE
Version 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## Version 1.2.2
+
+* __[fix]__ `option :orderBy, enum: %(price date)`, now expects a method `apply_order_by_x`, instead of `apply_orderBy_with_`
+
 ## Version 1.2.1
 
 * __[feature]__ Add `default:` option to `sort_by` plugin (@rstankov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 
 ## Version 1.2.2
 
-* __[fix]__ `option :orderBy, enum: %(price date)`, now expects a method `apply_order_by_x`, instead of `apply_orderBy_with_`
+* __[feature]__ Added `SearchObject::Base#params=` method, to reset search results (@rstankov)
+* __[change]__ `option :orderBy, enum: %(price date)`, now expects a method `apply_order_by_x`, instead of `apply_orderBy_with_` (__backward incompatible__) (@rstankov)
 
 ## Version 1.2.1
 
-* __[feature]__ Add `default:` option to `sort_by` plugin (@rstankov)
+* __[feature]__ Added `default:` option to `sort_by` plugin (@rstankov)
 
 ```ruby
 class ProductSearch
@@ -21,7 +22,7 @@ end
 
 ## Version 1.2.0
 
-* __[feature]__ `enum` plugin added (@rstankov)
+* __[feature]__ Added `enum` plugin (@rstankov)
 
 ```ruby
 class ProductSearch

--- a/example/README.md
+++ b/example/README.md
@@ -19,9 +19,9 @@ This is example application showing, one of the possible usages of ```SearchObje
 ```
 gem install bundler
 bundle install
-rake db:create
-rake db:migrate
-rake db:seed
+rails db:create
+rails db:migrate
+rails db:seed
 
 rails server
 ```

--- a/lib/search_object.rb
+++ b/lib/search_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'search_object/version'
 require 'search_object/errors'
 require 'search_object/helper'

--- a/lib/search_object/base.rb
+++ b/lib/search_object/base.rb
@@ -4,9 +4,8 @@ module SearchObject
       base.extend ClassMethods
       base.instance_eval do
         @config = {
-          defaults:  {},
-          actions:   {},
-          scope:     nil
+          defaults: {},
+          options:  {}
         }
       end
     end
@@ -14,12 +13,15 @@ module SearchObject
     def initialize(options = {})
       config = self.class.config
       scope  = options[:scope] || (config[:scope] && instance_eval(&config[:scope]))
-      actions = config[:actions] || {}
-      params  = Helper.normalize_params(config[:defaults], options[:filters], actions.keys)
 
       raise MissingScopeError unless scope
 
-      @search = Search.new(scope, params, actions)
+      @search = Search.new(
+        scope: scope,
+        options: config[:options],
+        defaults: config[:defaults],
+        params: options[:filters]
+      )
     end
 
     def results
@@ -67,7 +69,7 @@ module SearchObject
         handler = options[:with] || block
 
         config[:defaults][name] = default unless default.nil?
-        config[:actions][name]  = Helper.normalize_search_handler(handler, name)
+        config[:options][name]  = Helper.normalize_search_handler(handler, name)
 
         define_method(name) { @search.param name }
       end

--- a/lib/search_object/base.rb
+++ b/lib/search_object/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Base
     def self.included(base)

--- a/lib/search_object/base.rb
+++ b/lib/search_object/base.rb
@@ -38,6 +38,12 @@ module SearchObject
       @count ||= @search.count self
     end
 
+    def params=(params)
+      @count = nil
+      @results = nil
+      @search.params = params
+    end
+
     def params(additions = {})
       if additions.empty?
         @search.params

--- a/lib/search_object/errors.rb
+++ b/lib/search_object/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   class MissingScopeError < ArgumentError
     def initialize(message = 'No scope provided. Scope can be defined on a class level or passed as an option.')

--- a/lib/search_object/helper.rb
+++ b/lib/search_object/helper.rb
@@ -54,10 +54,6 @@ module SearchObject
       end
     end
 
-    def normalize_params(defaults, filters, keys)
-      (defaults || {}).merge(slice_keys(stringify_keys(filters || {}), keys || []))
-    end
-
     def deep_copy(object) # rubocop:disable Metrics/MethodLength
       case object
       when Array

--- a/lib/search_object/helper.rb
+++ b/lib/search_object/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   # :api: private
   module Helper

--- a/lib/search_object/plugin/enum.rb
+++ b/lib/search_object/plugin/enum.rb
@@ -34,7 +34,7 @@ module SearchObject
             return handle_invalid_value(object: object, option: option, enums: enums, scope: scope, value: value)
           end
 
-          object.send("apply_#{option}_with_#{Helper.underscore(value)}", scope)
+          object.send("apply_#{Helper.underscore(option)}_with_#{Helper.underscore(value)}", scope)
         end
 
         def handle_invalid_value(object:, option:, enums:, scope:, value:)

--- a/lib/search_object/plugin/enum.rb
+++ b/lib/search_object/plugin/enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module Enum

--- a/lib/search_object/plugin/kaminari.rb
+++ b/lib/search_object/plugin/kaminari.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module Kaminari

--- a/lib/search_object/plugin/model.rb
+++ b/lib/search_object/plugin/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module Model

--- a/lib/search_object/plugin/paging.rb
+++ b/lib/search_object/plugin/paging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module Paging

--- a/lib/search_object/plugin/sorting.rb
+++ b/lib/search_object/plugin/sorting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module Sorting

--- a/lib/search_object/plugin/will_paginate.rb
+++ b/lib/search_object/plugin/will_paginate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   module Plugin
     module WillPaginate

--- a/lib/search_object/search.rb
+++ b/lib/search_object/search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   # :api: private
   class Search

--- a/lib/search_object/search.rb
+++ b/lib/search_object/search.rb
@@ -3,19 +3,25 @@ module SearchObject
   class Search
     attr_reader :params
 
-    def initialize(scope, params, actions)
-      @scope    = scope
-      @actions  = actions
-      @params   = params
+    def initialize(scope:, options: nil, defaults: nil, params: nil)
+      @scope = scope
+      @options = options || {}
+      @defaults = defaults || {}
+
+      self.params = params
+    end
+
+    def params=(params)
+      @params = @defaults.merge(Helper.slice_keys(Helper.stringify_keys(params || {}), @options.keys))
     end
 
     def param(name)
-      @params[name]
+      @params[name.to_s]
     end
 
     def query(context)
       @params.inject(@scope) do |scope, (name, value)|
-        new_scope = context.instance_exec scope, value, &@actions[name]
+        new_scope = context.instance_exec scope, value, &@options[name]
         new_scope || scope
       end
     end

--- a/lib/search_object/version.rb
+++ b/lib/search_object/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchObject
   VERSION = '1.2.2'.freeze
 end

--- a/lib/search_object/version.rb
+++ b/lib/search_object/version.rb
@@ -1,3 +1,3 @@
 module SearchObject
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end

--- a/spec/search_object/base_spec.rb
+++ b/spec/search_object/base_spec.rb
@@ -282,6 +282,23 @@ module SearchObject
       end
     end
 
+    describe '#params=' do
+      it 'resets search' do
+        search = new_search [1, 2, 3], value: 1 do
+          option :value do |scope, value|
+            scope.select { |v| v > value }
+          end
+        end
+
+        expect(search.results).to eq [2, 3]
+        expect(search.count).to eq 2
+
+        search.params = { value: 2 }
+        expect(search.results).to eq [3]
+        expect(search.count).to eq 1
+      end
+    end
+
     describe '#params' do
       it 'exports options as params' do
         search = new_search [], value: 1

--- a/spec/search_object/helper_spec.rb
+++ b/spec/search_object/helper_spec.rb
@@ -41,24 +41,6 @@ module SearchObject
       end
     end
 
-    describe '.normalize_filters' do
-      it 'combines defaults and filters' do
-        expect(described_class.normalize_params({ 'a' => 1, 'b' => 2 }, { a: 2 }, %w[a b])).to eq 'a' => 2, 'b' => 2
-      end
-
-      it 'excludes non specified keys' do
-        expect(described_class.normalize_params({ 'a' => 1 }, { b: 2 }, %w[a])).to eq 'a' => 1
-      end
-
-      it 'handles missing defaults' do
-        expect(described_class.normalize_params(nil, { a: 1 }, %w[a])).to eq 'a' => 1
-      end
-
-      it 'handles missing filters' do
-        expect(described_class.normalize_params(nil, nil, ['a'])).to eq({})
-      end
-    end
-
     describe 'deep_copy' do
       it 'returns a deep copy on the given object' do
         original = {

--- a/spec/search_object/plugin/enum_spec.rb
+++ b/spec/search_object/plugin/enum_spec.rb
@@ -10,6 +10,7 @@ module SearchObject
         scope { [1, 2, 3, 4, 5] }
 
         option :filter, enum: %w[odd even]
+        option :camelCase, enum: %w[someValue]
 
         private
 
@@ -19,6 +20,10 @@ module SearchObject
 
         def apply_filter_with_even(scope)
           scope.select(&:even?)
+        end
+
+        def apply_camel_case_with_some_value(_scope)
+          [1]
         end
 
         def handle_invalid_filter(_scope, value)
@@ -38,6 +43,10 @@ module SearchObject
 
       it 'handles wrong enum values' do
         expect(TestSearch.results(filters: { filter: 'foo' })).to eq 'invalid filter - foo'
+      end
+
+      it 'underscores method and enum values' do
+        expect(TestSearch.results(filters: { camelCase: 'someValue' })).to eq [1]
       end
 
       it 'raises when block is passed with enum option' do


### PR DESCRIPTION
Changes:

* __[feature]__ Added `SearchObject::Base#params=` method, to reset search results (@rstankov)
* __[change]__ `option :orderBy, enum: %(price date)`, now expects a method `apply_order_by_x`, instead of `apply_orderBy_with_` (__backward incompatible__) (@rstankov)