### PR TITLE
Add improved enum handling

### DIFF
--- a/lib/search_object/plugin/enum.rb
+++ b/lib/search_object/plugin/enum.rb
@@ -11,10 +11,7 @@ module SearchObject
         def option(name, options = nil, &block)
           return super unless options.is_a?(Hash) && options[:enum]
 
-          raise BlockIgnoredError if block
-          raise WithIgnoredError if options[:with]
-
-          handler = Handler.build(name, options[:enum])
+          handler = options[:with] || block || Handler.build(name, options[:enum])
 
           super(name, options, &handler)
         end


### PR DESCRIPTION
This concerns #17 as discussed, `rake` passes successfully :ok_hand: 