### PR TITLE
Add Ruby 3 support to the example app

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '6.0.2.1'
+gem 'rails', '6.1.5'
 
 gem 'bootstrap-sass'
 gem 'jquery-rails'
@@ -10,5 +10,6 @@ gem 'rspec-rails'
 gem 'sass-rails', '~> 5.0.0'
 gem 'slim'
 gem 'sqlite3'
+gem 'webrick', '~> 1.8'
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'

--- a/example/config/boot.rb
+++ b/example/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/example/db/schema.rb
+++ b/example/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2013_11_02_130413) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
+    t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_users_on_name", unique: true


### PR DESCRIPTION
In Ruby 3.0, positional arguments and keyword arguments are separated. This is a breaking change and requires code changes. Rails has solved that compatibility change in 6.1, but the changes have not been ported to 6.0. This commit updates Rails to 6.1 and:

- It explicitly adds the webrick gem to the Gemfile since it no longer comes bundled with Ruby 3.0
- It changes `File.exists?` to `File.exist?` since the former is not available in Ruby 3.0